### PR TITLE
WIP: Allow importing and calling main

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -101,10 +101,10 @@ def get_parser():
     return parser
 
 
-def main():
+def main(args=None):
     """Entry point"""
     warnings.showwarning = _warn_redirect
-    opts = get_parser().parse_args()
+    opts = get_parser().parse_args(args)
     if opts.debug:
         logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Here's on option to address #6 

First, I removed the defaults from argparse and put them in `create_workflow`. This actually ends up not mattering much but IMO its cleaner and more explicit

More importantly, `main` now takes an `args` argument which is passed to `parse_args`. 
So now you can do the followng:

    from fitlins.cli.run import main
    main('dataset', 'output_dir', 'dataset', '--model=model.json')

and argparse will parse it. If no argument is passed, command line arguments (from sys) are passed in instead.

There's probably a better way to have a library CLI but for now this is good enough for me. 