### PR TITLE
WIP: Neuroscout related changes

### DIFF
--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -79,7 +79,7 @@ def get_parser():
                              'removed)')
     g_bids.add_argument('-m', '--model', action='store', default='model.json',
                         help='location of BIDS model description (default bids_dir/model.json)')
-    g_bids.add_argument('-d', '--derivatives', action='append',
+    g_bids.add_argument('-d', '--derivatives', action='store', nargs='+',
                         help='location of derivatives (including preprocessed images).'
                         'If none specified, indexes all derivatives under bids_dir/derivatives.')
     g_bids.add_argument('--derivative-label', action='store', type=str,

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -139,7 +139,7 @@ def run_fitlins(argv=None):
     if opts.model in (None, 'default') and not op.exists(model):
         model = 'default'
 
-    derivatives = True if not opts.derivatves else opts.derivatives
+    derivatives = True if not opts.derivatives else opts.derivatives
 
     pipeline_name = 'fitlins'
     if opts.derivative_label:

--- a/fitlins/cli/run.py
+++ b/fitlins/cli/run.py
@@ -79,9 +79,9 @@ def get_parser():
                              'removed)')
     g_bids.add_argument('-m', '--model', action='store', default='model.json',
                         help='location of BIDS model description (default bids_dir/model.json)')
-    g_bids.add_argument('-p', '--preproc-dir', action='store', default='fmriprep',
-                        help='location of preprocessed data (if relative path, search '
-                             'bids_dir/derivatives, followed by output_dir)')
+    g_bids.add_argument('-d', '--derivatives', action='append',
+                        help='location of derivatives (including preprocessed images).'
+                        'If none specified, indexes all derivatives under bids_dir/derivatives.')
     g_bids.add_argument('--derivative-label', action='store', type=str,
                         help='execution label to append to derivative directory name')
     g_bids.add_argument('--space', action='store',
@@ -139,13 +139,7 @@ def run_fitlins(argv=None):
     if opts.model in (None, 'default') and not op.exists(model):
         model = 'default'
 
-    preproc_dir = default_path(opts.preproc_dir,
-                               op.join(opts.bids_dir, 'derivatives'),
-                               'fmriprep')
-    if not op.exists(preproc_dir):
-        preproc_dir = default_path(opts.preproc_dir, opts.output_dir, 'fmriprep')
-        if not op.exists(preproc_dir):
-            raise RuntimeError("Preprocessed data could not be found")
+    derivatives = True if not opts.derivatves else opts.derivatives
 
     pipeline_name = 'fitlins'
     if opts.derivative_label:
@@ -158,7 +152,7 @@ def run_fitlins(argv=None):
     work_dir = mkdtemp() if opts.work_dir is None else opts.work_dir
 
     fitlins_wf = init_fitlins_wf(
-        opts.bids_dir, preproc_dir, deriv_dir, opts.space, model=model,
+        opts.bids_dir, derivatives, deriv_dir, opts.space, model=model,
         participants=subject_list, base_dir=work_dir,
         include_pattern=opts.include, exclude_pattern=opts.exclude
         )

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -103,13 +103,13 @@ class ModelSpecLoader(SimpleInterface):
             layout = bids.BIDSLayout(self.inputs.bids_dir, validate=False)
 
             if not isdefined(models):
-                models = layout.get(suffix='smdl')
+                models = layout.get(suffix='smdl', return_type='file')
                 if not models:
                     raise ValueError("No models found")
             elif models == 'default':
                 models = auto_model(layout)
 
-        models = [_ensure_model(m.path) for m in models]
+        models = [_ensure_model(m) for m in models]
 
         if self.inputs.selectors:
             # This is almost certainly incorrect

--- a/fitlins/interfaces/bids.py
+++ b/fitlins/interfaces/bids.py
@@ -136,8 +136,8 @@ class LoadBIDSModelInputSpec(BaseInterfaceInputSpec):
     bids_dir = Directory(exists=True,
                          mandatory=True,
                          desc='BIDS dataset root directory')
-    preproc_dir = Directory(exists=True,
-                            desc='Optional preprocessed files directory')
+    derivatives = traits.Either(traits.Bool, InputMultiPath(Directory(exists=True)),
+                                desc='Derivative folders')
     model = traits.Dict(desc='Model specification', mandatory=True)
     selectors = traits.Dict(desc='Limit collected sessions', usedefault=True)
     include_pattern = InputMultiPath(
@@ -164,7 +164,7 @@ class LoadBIDSModel(SimpleInterface):
         import bids
         include = self.inputs.include_pattern
         exclude = self.inputs.exclude_pattern
-        derivatives = self.inputs.preproc_dir
+        derivatives = self.inputs.derivatives
         if not isdefined(include):
             include = None
         if not isdefined(exclude):
@@ -172,8 +172,8 @@ class LoadBIDSModel(SimpleInterface):
         if not isdefined(derivatives):
             exclude = False
 
-        layout = bids.BIDSLayout(self.inputs.bids_dir, include=include, exclude=exclude,
-                                 derivatives=derivatives)
+        layout = bids.BIDSLayout(self.inputs.bids_dir, include=include,
+                                 exclude=exclude, derivatives=derivatives)
 
         selectors = self.inputs.selectors
 
@@ -364,8 +364,8 @@ class BIDSSelectInputSpec(BaseInterfaceInputSpec):
     bids_dir = Directory(exists=True,
                          mandatory=True,
                          desc='BIDS dataset root directories')
-    preproc_dir = Directory(exists=True,
-                            desc='Optional preprocessed files directory')
+    derivatives = traits.Either(True, InputMultiPath(Directory(exists=True)),
+                                desc='Derivative folders')
     entities = InputMultiPath(traits.Dict(), mandatory=True)
     selectors = traits.Dict(desc='Additional selectors to be applied',
                             usedefault=True)
@@ -384,10 +384,7 @@ class BIDSSelect(SimpleInterface):
     def _run_interface(self, runtime):
         import bids
 
-        derivatives = self.inputs.preproc_dir
-        if not isdefined(derivatives):
-            exclude = False
-
+        derivatives = self.inputs.derivatives
         layout = bids.BIDSLayout(self.inputs.bids_dir, derivatives=derivatives)
 
         bold_files = []

--- a/fitlins/workflows/base.py
+++ b/fitlins/workflows/base.py
@@ -9,7 +9,7 @@ from ..interfaces.visualizations import (
 from ..interfaces.utils import MergeAll
 
 
-def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, exclude_pattern=None,
+def init_fitlins_wf(bids_dir, derivatives, out_dir, space, exclude_pattern=None,
                     include_pattern=None, model=None, participants=None,
                     base_dir=None, name='fitlins_wf'):
     wf = pe.Workflow(name=name, base_dir=base_dir)
@@ -31,12 +31,10 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, exclude_pattern=None,
 
     loader = pe.Node(
         LoadBIDSModel(bids_dir=bids_dir,
-                      preproc_dir=preproc_dir,
+                      derivatives=derivatives,
                       selectors=selectors),
         name='loader')
 
-    if preproc_dir is not None:
-        loader.inputs.preproc_dir = preproc_dir
     if exclude_pattern is not None:
         loader.inputs.exclude_pattern = exclude_pattern
     if include_pattern is not None:
@@ -53,12 +51,9 @@ def init_fitlins_wf(bids_dir, preproc_dir, out_dir, space, exclude_pattern=None,
 
     # Select preprocessed BOLD series to analyze
     getter = pe.Node(
-        BIDSSelect(bids_dir=bids_dir,
+        BIDSSelect(bids_dir=bids_dir, derivatives=derivatives,
                    selectors={'type': 'preproc', 'space': space}),
         name='getter')
-
-    if preproc_dir is not None:
-        getter.inputs.preproc_dir = preproc_dir
 
     select_l1_contrasts = pe.Node(niu.Select(index=0), name='select_l1_contrasts')
 


### PR DESCRIPTION
- [x] `ModelSpecLoader` is not working working when the model was specified as a string, rather than extract from the filesystem using `BIDSLayout`. I fix that here
Not sure this will work w/ `auto_model`. Doesn't that return a dictionary (not a path, or json in string format)?
- [x]  I need to be able to specify more than a single derivatives dir (neuroscout event files, fmriprep files) Changing fitlins to allow multiple derivatives, as in `BIDSLayout`